### PR TITLE
Update woo-better-reviews.php

### DIFF
--- a/woo-better-reviews.php
+++ b/woo-better-reviews.php
@@ -9,7 +9,7 @@
  * Text Domain: woo-better-reviews
  * Domain Path: /languages
  * WC requires at least: 4.2.0
- * WC tested up to: 4.4.1
+ * WC tested up to: 5.3.1
  * License:     MIT
  * License URI: https://opensource.org/licenses/MIT
  *


### PR DESCRIPTION
After putting this in a WC Beta site, let's go ahead and update the "tested to" version to reflect that this plugin is still working with the current version of WooCommerce.